### PR TITLE
Use random topic name in integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ build: $(GO_SOURCES)
 	go build $(PKGS)
 
 test: $(GO_SOURCES)
-	-kafka-topics --delete --zookeeper localhost:2181 --topic test-topic
-	-kafka-topics --create --zookeeper localhost:2181 --topic test-topic --partitions 1 --replication-factor 1
 	KAFKA_BROKERS=localhost:9092 go test -v ./...
 
 gen-mocks $(GENERATED_SOURCE): $(GO_SOURCES)

--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,8 @@ make build
 
 === Testing
 
-Ensure Kafka and Zookeepr are running locally, then issue:
+Ensure Kafka (with `auto.create.topics.enable=true`, which is the default) and Zookeepr are running locally,
+then issue:
 [source, bash]
 ----
 make test

--- a/pkg/transport/kafka/kafka_integration_test.go
+++ b/pkg/transport/kafka/kafka_integration_test.go
@@ -33,15 +33,16 @@ import (
 
 var _ = Describe("Kafka Integration", func() {
 
-	const topic = "test-topic"
-
 	var (
+		topic string
 		producer    transport.Producer
 		consumer    transport.Consumer
 		testMessage message.Message
 	)
 
 	BeforeEach(func() {
+		topic = fmt.Sprintf("topic-%d", time.Now().Nanosecond())
+
 		testMessage = message.NewMessage([]byte("hello"), message.Headers{"Content-Type": []string{"bag/plastic"}})
 
 		brokers := brokers()


### PR DESCRIPTION
This avoids the need to delete the topic in the makefile, which may not be
configured to work.

Fixes https://github.com/projectriff/message-transport/issues/5.